### PR TITLE
Autocomplete component enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "primeng",
+  "name": "im-primeng",
   "version": "7.1.0-SNAPSHOT",
   "license": "MIT",
   "scripts": {
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/primefaces/primeng.git"
+    "url": "https://github.com/imanage-ext/primeng"
   },
   "devDependencies": {
     "@angular/animations": "~7.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/imanage-ext/primeng"
+    "url": "https://github.com/imanage-ext/primeng.git"
   },
   "devDependencies": {
     "@angular/animations": "~7.1.0",

--- a/src/app/components/autocomplete/autocomplete.css
+++ b/src/app/components/autocomplete/autocomplete.css
@@ -54,6 +54,11 @@
     text-align: left;
 }
 
+.ui-autocomplete-panel .ui-autocomplete-items .ui-autocomplete-list-item:hover {
+    background-color: #007ad9;
+    color: white;
+}
+
 .ui-autocomplete .ui-button-icon-only,
 .ui-autocomplete .ui-button-icon-only:enabled:hover,
 .ui-autocomplete .ui-button-icon-only:enabled:focus,
@@ -129,16 +134,16 @@
 
 .ui-autocomplete-dd input.ui-corner-all ,
 .ui-autocomplete-dd .ui-autocomplete-multiple-container.ui-corner-all {
-     -moz-border-radius-topright: 0px; 
+     -moz-border-radius-topright: 0px;
      -webkit-border-top-right-radius: 0px;
      border-top-right-radius: 0px;
      -moz-border-radius-bottomright: 0px;
      -webkit-border-bottom-right-radius: 0px;
      border-bottom-right-radius: 0px;
  }
- 
+
 .ui-autocomplete-dd .ui-autocomplete-dropdown.ui-corner-all {
-     -moz-border-radius-topleft: 0px; 
+     -moz-border-radius-topleft: 0px;
      -webkit-border-top-left-radius: 0px;
      border-top-left-radius: 0px;
      -moz-border-radius-bottomleft: 0px;

--- a/src/app/components/autocomplete/autocomplete.spec.ts
+++ b/src/app/components/autocomplete/autocomplete.spec.ts
@@ -44,12 +44,12 @@ class TestAutocompleteComponent {
 }
 
 describe('AutoComplete', () => {
-  
+
     let autocomplete: AutoComplete;
     let autocomplete2: AutoComplete;
     let testComponent: TestAutocompleteComponent;
     let fixture: ComponentFixture<TestAutocompleteComponent>;
-  
+
     beforeEach(() => {
     TestBed.configureTestingModule({
 
@@ -62,7 +62,7 @@ describe('AutoComplete', () => {
         TestAutocompleteComponent,
       ]
     });
-    
+
     fixture = TestBed.createComponent(TestAutocompleteComponent);
     autocomplete = fixture.debugElement.children[0].componentInstance;
     autocomplete2 = fixture.debugElement.children[2].componentInstance;
@@ -155,7 +155,7 @@ describe('AutoComplete', () => {
       let focusValue;
       autocomplete.onFocus.subscribe(value => focusValue = value);
       const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
@@ -172,7 +172,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const suggestionsEls = fixture.debugElement.queryAll(By.css('li'));
       expect(autocomplete.suggestions.length).toEqual(2);
       expect(suggestionsEls.length).toEqual(2);
@@ -196,7 +196,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
@@ -208,7 +208,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const suggestionsEls = fixture.debugElement.queryAll(By.css('li'));
       const panelEl = fixture.debugElement.query(By.css('div'));
       expect(panelEl.nativeElement.style.maxHeight).toEqual("450px")
@@ -223,7 +223,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
@@ -235,7 +235,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const suggestionsEls = fixture.debugElement.queryAll(By.css('li'));
       expect(autocomplete.suggestions.length).toEqual(2);
       expect(suggestionsEls.length).toEqual(2);
@@ -248,7 +248,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
@@ -260,7 +260,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const suggestionsEls = fixture.debugElement.queryAll(By.css('li'));
       expect(autocomplete.suggestions.length).toEqual(2);
       expect(suggestionsEls.length).toEqual(2);
@@ -272,7 +272,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
@@ -283,7 +283,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const suggestionsEls = fixture.debugElement.queryAll(By.css('li'));
       expect(autocomplete.suggestions.length).toEqual(0);
       expect(suggestionsEls.length).toEqual(0);
@@ -295,7 +295,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
@@ -314,7 +314,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const suggestionsEls = fixture.debugElement.queryAll(By.css('li'));
       expect(autocomplete.suggestions.length).toEqual(0);
       expect(suggestionsEls.length).toEqual(1);
@@ -328,28 +328,72 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
-      
+
       inputEl.nativeElement.value = "v";
       inputEl.nativeElement.dispatchEvent(new Event('keydown'));
       inputEl.nativeElement.dispatchEvent(new Event('input'));
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const firstItemEl = fixture.debugElement.query(By.css('li')).nativeElement;
       expect(firstItemEl.className).toContain('ui-state-highlight');
     }));
+
+    it('should use autoHighlightOnlySuggestion and highlight if only one suggestion', fakeAsync(() => {
+        autocomplete.autoHighlightOnlySuggestion = true;
+        autocomplete.baseZIndex = 20;
+        fixture.detectChanges();
+
+        const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
+        inputEl.nativeElement.dispatchEvent(new Event('focus'));
+        inputEl.nativeElement.focus();
+        inputEl.nativeElement.click();
+        fixture.detectChanges();
+
+        inputEl.nativeElement.value = "v";
+        inputEl.nativeElement.dispatchEvent(new Event('keydown'));
+        inputEl.nativeElement.dispatchEvent(new Event('input'));
+        inputEl.nativeElement.dispatchEvent(new Event('keyup'));
+        tick(300);
+        fixture.detectChanges();
+
+        const firstItemEl = fixture.debugElement.query(By.css('li')).nativeElement;
+        expect(firstItemEl.className).not.toContain('ui-state-highlight');
+      }));
+
+      it('should use autoHighlightOnlySuggestion and highlight if only one suggestion', fakeAsync(() => {
+        autocomplete.autoHighlightOnlySuggestion = true;
+        autocomplete.baseZIndex = 20;
+        fixture.detectChanges();
+
+        const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
+        inputEl.nativeElement.dispatchEvent(new Event('focus'));
+        inputEl.nativeElement.focus();
+        inputEl.nativeElement.click();
+        fixture.detectChanges();
+
+        inputEl.nativeElement.value = "vo";
+        inputEl.nativeElement.dispatchEvent(new Event('keydown'));
+        inputEl.nativeElement.dispatchEvent(new Event('input'));
+        inputEl.nativeElement.dispatchEvent(new Event('keyup'));
+        tick(300);
+        fixture.detectChanges();
+
+        const firstItemEl = fixture.debugElement.query(By.css('li')).nativeElement;
+        expect(firstItemEl.className).toContain('ui-state-highlight');
+      }));
 
     it('should use forceSelection', fakeAsync(() => {
       autocomplete.forceSelection = true;
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
@@ -363,7 +407,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('change'));
       tick(300);
       fixture.detectChanges();
-      
+
       expect(inputEl.nativeElement.value).toEqual('');
     }));
 
@@ -371,7 +415,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
@@ -383,7 +427,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const firstItemEl = fixture.debugElement.query(By.css('li')).nativeElement;
       firstItemEl.click();
       fixture.detectChanges();
@@ -402,7 +446,7 @@ describe('AutoComplete', () => {
       const dropdownOpenEl = fixture.debugElement.query(By.css('.ui-autocomplete-dropdown'));
       dropdownOpenEl.nativeElement.click();
       fixture.detectChanges();
-      
+
       const panelEl = fixture.debugElement.query(By.css('div'));
       expect(panelEl).toBeTruthy();
       expect(autocomplete.overlayVisible).toEqual(true);
@@ -417,7 +461,7 @@ describe('AutoComplete', () => {
       const dropdownOpenEl = fixture.debugElement.query(By.css('.ui-autocomplete-dropdown'));
       dropdownOpenEl.nativeElement.click();
       fixture.detectChanges();
-      
+
       const panelEl = fixture.debugElement.query(By.css('div'));
       expect(panelEl).toBeTruthy();
       expect(autocomplete.overlayVisible).toEqual(true);
@@ -429,7 +473,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.queryAll(By.css('p-autoComplete'))[1].query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
@@ -441,7 +485,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const firstItemEl = fixture.debugElement.queryAll(By.css('p-autoComplete'))[1].query(By.css('li')).nativeElement;
       firstItemEl.click();
       fixture.detectChanges();
@@ -455,7 +499,7 @@ describe('AutoComplete', () => {
       autocomplete.minLength = 2;
       fixture.detectChanges();
       const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
@@ -468,7 +512,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const panelEl = fixture.debugElement.query(By.css('div'));
-      expect(panelEl).toBeFalsy();      
+      expect(panelEl).toBeFalsy();
     }));
 
     it('should multiple', () => {
@@ -487,7 +531,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('input'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.click();
       fixture.detectChanges();
 
@@ -498,7 +542,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       inputEl.nativeElement.dispatchEvent(new Event('change'));
       const firstItemEl = fixture.debugElement.queryAll(By.css('li'))[1].nativeElement;
       firstItemEl.click();
@@ -514,7 +558,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('input'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.click();
       fixture.detectChanges();
 
@@ -525,7 +569,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const firstItemEl = fixture.debugElement.queryAll(By.css('li'))[1].nativeElement;
       firstItemEl.click();
       fixture.detectChanges();
@@ -541,7 +585,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('input'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.click();
       fixture.detectChanges();
 
@@ -552,7 +596,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const firstItemEl = fixture.debugElement.queryAll(By.css('li'))[1].nativeElement;
       firstItemEl.click();
       fixture.detectChanges();
@@ -573,7 +617,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('input'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.click();
       fixture.detectChanges();
 
@@ -584,7 +628,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const firstItemEl = fixture.debugElement.queryAll(By.css('li'))[1].nativeElement;
       firstItemEl.click();
       fixture.detectChanges();
@@ -604,7 +648,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('input'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.click();
       fixture.detectChanges();
 
@@ -630,7 +674,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('input'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.click();
       fixture.detectChanges();
 
@@ -652,10 +696,10 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('input'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.click();
       fixture.detectChanges();
-     
+
       const selectItemSpy = spyOn(autocomplete, 'selectItem').and.callThrough();
       const hideSpy = spyOn(autocomplete, 'hide').and.callThrough();
       autocomplete.suggestions = ["Volvo","VW"]

--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -30,17 +30,17 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                 </li>
                 <li class="ui-autocomplete-input-token">
                     <input #multiIn [attr.type]="type" [attr.id]="inputId" [disabled]="disabled" [attr.placeholder]="(value&&value.length ? null : placeholder)" [attr.tabindex]="tabindex" (input)="onInput($event)"  (click)="onInputClick($event)"
-                            (keydown)="onKeydown($event)" [readonly]="readonly" (keyup)="onKeyup($event)" [attr.autofocus]="autofocus" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" (change)="onInputChange($event)" (paste)="onInputPaste($event)" autocomplete="off" 
+                            (keydown)="onKeydown($event)" [readonly]="readonly" (keyup)="onKeyup($event)" [attr.autofocus]="autofocus" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" (change)="onInputChange($event)" (paste)="onInputPaste($event)" autocomplete="off"
                             [ngStyle]="inputStyle" [class]="inputStyleClass" [attr.aria-label]="ariaLabel" [attr.aria-labelledby]="ariaLabelledBy" [attr.aria-required]="required">
                 </li>
             </ul
             ><i *ngIf="loading" class="ui-autocomplete-loader pi pi-spinner pi-spin"></i><button #ddBtn type="button" pButton icon="pi pi-fw pi-caret-down" class="ui-autocomplete-dropdown" [disabled]="disabled"
-                (click)="handleDropdownClick($event)" *ngIf="dropdown"></button>
+                (click)="handleDropdownClick($event)" *ngIf="dropdown" tabindex="-1"></button>
             <div #panel *ngIf="overlayVisible" class="ui-autocomplete-panel ui-widget ui-widget-content ui-corner-all ui-shadow" [style.max-height]="scrollHeight"
                 [@overlayAnimation]="{value: 'visible', params: {showTransitionParams: showTransitionOptions, hideTransitionParams: hideTransitionOptions}}" (@overlayAnimation.start)="onOverlayAnimationStart($event)" (@overlayAnimation.done)="onOverlayAnimationDone($event)">
                 <ul class="ui-autocomplete-items ui-autocomplete-list ui-widget-content ui-widget ui-corner-all ui-helper-reset">
                     <li *ngFor="let option of suggestions; let idx = index" [ngClass]="{'ui-autocomplete-list-item ui-corner-all':true,'ui-state-highlight':(highlightOption==option)}"
-                        (mouseenter)="highlightOption=option" (mouseleave)="highlightOption=null" (click)="selectItem(option)">
+                        (mouseenter)="highlightOnMouseHover ? highlightOption=option : ''" (mouseleave)="highlightOnMouseHover ? highlightOption=null : ''" (click)="selectItem(option)">
                         <span *ngIf="!itemTemplate">{{resolveFieldData(option)}}</span>
                         <ng-container *ngTemplateOutlet="itemTemplate; context: {$implicit: option, index: idx}"></ng-container>
                     </li>
@@ -101,12 +101,16 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,DoCheck,C
 
     @Input() autoHighlight: boolean;
 
+    @Input() autoHighlightOnlySuggestion: boolean;
+
+    @Input() highlightOnMouseHover: boolean = true;
+
     @Input() forceSelection: boolean;
 
     @Input() type: string = 'text';
 
     @Input() autoZIndex: boolean = true;
-    
+
     @Input() baseZIndex: number = 0;
 
     @Input() ariaLabel: string;
@@ -219,7 +223,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,DoCheck,C
 
     set suggestions(val:any[]) {
         this._suggestions = val;
-        
+
         if (this.immutable) {
             this.handleSuggestionsChange();
         }
@@ -264,6 +268,10 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,DoCheck,C
                 if (this.autoHighlight) {
                     this.highlightOption = this._suggestions[0];
                 }
+
+                if (this.autoHighlightOnlySuggestion && this._suggestions.length === 1) {
+                    this.highlightOption = this._suggestions[0];
+                }
             }
             else {
                 this.noResults = true;
@@ -276,7 +284,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,DoCheck,C
                     this.hide();
                 }
             }
-    
+
             this.loading = false;
         }
     }
@@ -401,7 +409,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,DoCheck,C
     show() {
         if (this.multiInputEL || this.inputEL) {
             let hasFocus = this.multiple ? document.activeElement == this.multiInputEL.nativeElement : document.activeElement == this.inputEL.nativeElement ;
-            
+
             if (!this.overlayVisible && hasFocus) {
                 this.overlayVisible = true;
             }
@@ -711,7 +719,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,DoCheck,C
         this.documentResizeListener = this.onWindowResize.bind(this);
         window.addEventListener('resize', this.documentResizeListener);
     }
-    
+
     unbindDocumentResizeListener() {
         if (this.documentResizeListener) {
             window.removeEventListener('resize', this.documentResizeListener);


### PR DESCRIPTION
### Features added
- The **autocomplete** component allows the user to mouse hover over a suggestion in the dropdown and select it by hitting the *Tab* key. But this can cause accidental updates when keyboard navigating and the mouse pointer is present where the suggestion dropdown shows. A new input property *highlightOnMouseHover* has now been added to the autocomplete component to  disable this behavior. This property is set to `true` by default and will continue to behave as explained above. But if the developer passes the value `false` to this property, the mouse hover will continue to highlight the suggestion, but will not select it on hitting *Tab*.
- When keyboard navigating across multiple **autocomplete** fields with the dropdown buttons, the tab moves from the input to the dropdown button before navigating to the next autocomplete field. Where there are a large number of these fields, this can result in a tedious amount of tabbing before getting to another field. In order to avoid this, the dropdown button now has `tabindex="-1"` set on it.
- The **autocomplete** component has the option to highlight the first item in the suggestions list. This is set by using the input property `autoHighlight`. But this will always highlight the first suggestion and hence cause the problem of selecting the first item when Tabbing from one field to the other. But at the same time, the user would like this to be enabled in cases where they start typing and only one suggestion is left and want to select it. To allow this, we have added another input property called `autoHighlightOnlySuggestion`. This will only highlight the first suggestion if it is the only one.

### Defect Fixes
When submitting a PR, please also create an issue documenting the error.

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.