### PR TITLE
added support for keydown events on top of the existing keyup events. updated readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,10 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+
+# Built files
+*.js
+*.d.ts
+!gulpfile.js
+!primeng.d.ts
+!primeng.js

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See [PrimeNG homepage](http://www.primefaces.org/primeng) for live showcase and 
 
 - The autocomplete component has the option to highlight the first item in the suggestions list. This is set by using the input property autoHighlight. But this will always highlight the first suggestion and hence cause the problem of selecting the first item when Tabbing from one field to the other. But at the same time, the user would like this to be enabled in cases where they start typing and only one suggestion is left and want to select it. To allow this, we have added another input property called **autoHighlightOnlySuggestion**. This will only highlight the first suggestion if it is the only one.
 
-- Two new events, **onKeyDown** and **onDropdownKeyDown** has been added to get the keydown events from the input and the dropdown items. This can be used to manipulate those events, prevent propagation of those events etc.
+- Two new events, **onKeyDown** and **onDropdownKeyDown** have been added to get the keydown events from the input and the dropdown items. This can be used to manipulate those events, prevent propagation of those events etc.
 
 ### Publishing to NPM
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,30 @@
 [![npm version](https://badge.fury.io/js/primeng.svg)](https://badge.fury.io/js/primeng)
 [![Build Status](https://travis-ci.org/primefaces/primeng.svg?branch=master)](https://travis-ci.org/primefaces/primeng)
 
-# PrimeNG
+# IM PrimeNG
 
-UI Components for Angular
+Forked from PrimeNG UI Components for Angular
 
 See [PrimeNG homepage](http://www.primefaces.org/primeng) for live showcase and documentation.
+
+### Additional Features in this fork
+
+- The autocomplete component allows the user to mouse hover over a suggestion in the dropdown and select it by hitting the Tab key. But this can cause accidental updates when keyboard navigating and the mouse pointer is present where the suggestion dropdown shows. A new input property **highlightOnMouseHover** has now been added to the autocomplete component to disable this behavior. This property is set to true by default and will continue to behave as explained above. But if the developer passes the value false to this property, the mouse hover will continue to highlight the suggestion, but will not select it on hitting Tab.
+
+- When keyboard navigating across multiple autocomplete fields with the dropdown buttons, the tab moves from the input to the dropdown button before navigating to the next autocomplete field. Where there are a large number of these fields, this can result in a tedious amount of tabbing before getting to another field. In order to avoid this, the dropdown button now has tabindex="-1" set on it.
+
+- The autocomplete component has the option to highlight the first item in the suggestions list. This is set by using the input property autoHighlight. But this will always highlight the first suggestion and hence cause the problem of selecting the first item when Tabbing from one field to the other. But at the same time, the user would like this to be enabled in cases where they start typing and only one suggestion is left and want to select it. To allow this, we have added another input property called **autoHighlightOnlySuggestion**. This will only highlight the first suggestion if it is the only one.
+
+- Two new events, **onKeyDown** and **onDropdownKeyDown** has been added to get the keydown events from the input and the dropdown items. This can be used to manipulate those events, prevent propagation of those events etc.
+
+### Publishing to NPM
+
+- Make the necesary changes
+- Update the version number in package.json
+- Run `npm run build-redistribute`
+- Run `npm publish`
+
+### About PrimeNG
 
 ![alt text](https://www.primefaces.org/wp-content/uploads/2018/05/primeng-sidebar.svg "PrimeNG")
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "im-primeng",
-  "version": "7.1.0-SNAPSHOT",
+  "version": "7.1.5-2",
   "license": "MIT",
   "scripts": {
     "ng": "ng",
@@ -8,12 +8,27 @@
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "build-components": "ngc -p tsconfig-release.json",
+    "clean-assets": "gulp clean",
+    "build-assets": "gulp build-assets",
+    "build-styles": "node-sass src/assets/components -o src/assets/components",
+    "build-redistribute": "npm run build-components && npm run clean-assets && npm run build-assets && npm run build-styles"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/imanage-ext/primeng.git"
   },
+  "files": [
+      "components/**/*.d.ts",
+      "components/**/*.js",
+      "components/**/*.js.map",
+      "components/**/*.metadata.json",
+      "components/**/*.d.ts",
+      "resources/**/*",
+      "*.d.ts",
+      "*.js"
+  ],
   "devDependencies": {
     "@angular/animations": "~7.1.0",
     "@angular/cdk": "~7.1.0",
@@ -64,6 +79,7 @@
     "quill": "1.3.6",
     "web-animations-js": "2.3.1",
     "primeicons": "1.0.0",
-    "primeflex": "1.0.0-rc.1"
+    "primeflex": "1.0.0-rc.1",
+    "node-sass": "^4.5.3"
   }
 }

--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -38,7 +38,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                 (click)="handleDropdownClick($event)" *ngIf="dropdown" tabindex="-1"></button>
             <div #panel *ngIf="overlayVisible" class="ui-autocomplete-panel ui-widget ui-widget-content ui-corner-all ui-shadow" [style.max-height]="scrollHeight"
                 [@overlayAnimation]="{value: 'visible', params: {showTransitionParams: showTransitionOptions, hideTransitionParams: hideTransitionOptions}}" (@overlayAnimation.start)="onOverlayAnimationStart($event)" (@overlayAnimation.done)="onOverlayAnimationDone($event)">
-                <ul class="ui-autocomplete-items ui-autocomplete-list ui-widget-content ui-widget ui-corner-all ui-helper-reset">
+                <ul class="ui-autocomplete-items ui-autocomplete-list ui-widget-content ui-widget ui-corner-all ui-helper-reset" (keydown)="onDropdownKeydown($event)">
                     <li *ngFor="let option of suggestions; let idx = index" [ngClass]="{'ui-autocomplete-list-item ui-corner-all':true,'ui-state-highlight':(highlightOption==option)}"
                         (mouseenter)="highlightOnMouseHover ? highlightOption=option : ''" (mouseleave)="highlightOnMouseHover ? highlightOption=null : ''" (click)="selectItem(option)">
                         <span *ngIf="!itemTemplate">{{resolveFieldData(option)}}</span>
@@ -132,6 +132,10 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,DoCheck,C
 	@Output() onClear: EventEmitter<any> = new EventEmitter();
 
     @Output() onKeyUp: EventEmitter<any> = new EventEmitter();
+
+    @Output() onKeyDown: EventEmitter<any> = new EventEmitter();
+
+    @Output() onDropdownKeyDown: EventEmitter<any> = new EventEmitter();
 
     @Input() field: string;
 
@@ -582,10 +586,15 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,DoCheck,C
         }
 
         this.inputKeyDown = true;
+        this.onKeyDown.emit(event);
     }
 
     onKeyup(event) {
         this.onKeyUp.emit(event);
+    }
+
+    onDropdownKeydown(event) {
+        this.onDropdownKeyDown.emit(event);
     }
 
     onInputFocus(event) {


### PR DESCRIPTION
Two new events, **onKeyDown** and **onDropdownKeyDown** have been added to get the keydown events from the input and the dropdown items. This can be used to manipulate those events, prevent propagation of those events etc.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.